### PR TITLE
Add defines for non-MSC GREETER/FAREWELLER_API

### DIFF
--- a/sample02/fareweller/include/fareweller/config.h
+++ b/sample02/fareweller/include/fareweller/config.h
@@ -10,4 +10,6 @@
 #	  define FAREWELLER_API
 #    endif
 #  endif
+#else
+#  define FAREWELLER_API
 #endif

--- a/sample02/greeter/include/greeter/config.h
+++ b/sample02/greeter/include/greeter/config.h
@@ -1,7 +1,5 @@
 #pragma once
 
-#pragma once
-
 #ifdef _MSC_VER
 #  ifdef GREETER_EXPORTS
 #   define GREETER_API __declspec(dllexport)
@@ -12,4 +10,6 @@
 #	  define GREETER_API
 #    endif
 #  endif
+#else
+#  define GREETER_API
 #endif


### PR DESCRIPTION
sample02 did not build on my Mac. Add defines for non-MSC GREETER/FAREWELLER_API.
